### PR TITLE
Add missing timescale directive to control.sv

### DIFF
--- a/00_src/control.sv
+++ b/00_src/control.sv
@@ -1,3 +1,4 @@
+`timescale 1ns/1ps
 module control(
   input  logic [31:0] instr,
   output logic [3:0]  alu_op,


### PR DESCRIPTION
## Summary
- add the `timescale 1ns/1ps` directive to `control.sv` to align with repository coding guidelines

## Testing
- make lint
