### PR TITLE
Guard IMEM high address range

### DIFF
--- a/00_src/imem.sv
+++ b/00_src/imem.sv
@@ -28,7 +28,11 @@ module imem (
     logic [10:0] word_idx;
     assign word_idx = addr[12:2];
     always_comb begin
-        if ({21'd0,word_idx} < MEM_WORDS) rdata = mem[word_idx];
-        else                      rdata = 32'h00000013; // NOP if out-of-range
+        if (addr[31:13] == 19'd0) begin
+            if ({21'd0, word_idx} < MEM_WORDS) rdata = mem[word_idx];
+            else                      rdata = 32'h0000_0013; // NOP if index overruns ROM depth
+        end else begin
+            rdata = 32'h0000_0013; // NOP if address above 0x0000_1FFF
+        end
     end
 endmodule


### PR DESCRIPTION
## Summary
- guard the IMEM word read with an explicit high-address check and drive a NOP for 0x2000+ fetches
- extend the cpu_tb to instantiate a ROM probe that verifies 0x0000_2000 returns the NOP instead of mem[0]

## Testing
- make lint
- make run *(fails: RED LED never observed; reproduces on main as well)*

------
https://chatgpt.com/codex/tasks/task_e_68ced3278010832da2982bf7f26c36a3